### PR TITLE
feat: Robustify test fixtures for parallel execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,11 @@ down: ## Stop and remove all development containers
 	@ln -sf .env.dev .env
 	$(SUDO) docker compose -f docker-compose.yml -f docker-compose.override.yml --project-name $(DEV_PROJECT_NAME) down --remove-orphans
 
+clean: ## Stop and remove all dev containers, networks, and volumes
+	@echo "Cleaning up all development Docker resources (including volumes)..."
+	@ln -sf .env.dev .env
+	$(SUDO) docker compose -f docker-compose.yml -f docker-compose.override.yml --project-name $(DEV_PROJECT_NAME) down --volumes --remove-orphans
+
 rebuild: ## Rebuild the api service without cache and restart it
 	@echo "Rebuilding api service with --no-cache..."
 	@ln -sf .env.dev .env

--- a/poetry.lock
+++ b/poetry.lock
@@ -315,6 +315,18 @@ standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "htt
 standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
+name = "filelock"
+version = "3.19.1"
+description = "A platform independent file lock."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d"},
+    {file = "filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58"},
+]
+
+[[package]]
 name = "greenlet"
 version = "3.2.4"
 description = "Lightweight in-process concurrent programming"
@@ -1730,4 +1742,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "7fb1b3165257d7316d088ccccadcacc9f15f990a920af5fbdfc2da635162ac25"
+content-hash = "c82136157fa0de3a9d2f1ea645ffb6b9f2a084a8dd392efff0b31956b222d5c8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ pytest-asyncio = "^0.23.7"
 watchdog = { extras = ["watchmedo"], version = "^4.0.1" }
 testcontainers = {extras = ["postgres"], version = "^4.6.0"}
 httpx = ">=0.27.0,<0.28.0"
+filelock = ">=3.12.2,<4.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
+import json
 import os
+from pathlib import Path
+from types import SimpleNamespace
 from typing import AsyncGenerator, Generator
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from filelock import FileLock
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -17,36 +21,94 @@ from src.main import app
 from src.middlewares import db_logging_middleware
 
 
-@pytest.fixture(scope="session")
-def db_container() -> PostgresContainer:
-    """
-    Fixture to create and manage a PostgreSQL container for the test session.
-    """
-    with PostgresContainer("postgres:16-alpine", driver="psycopg") as container:
-        yield container
+def is_xdist_worker(request: pytest.FixtureRequest) -> bool:
+    """Check if the current pytest session is running under pytest-xdist."""
+    return "worker_id" in request.fixturenames
 
 
 @pytest.fixture(scope="session")
-def db_url(db_container: PostgresContainer) -> str:
+def db_container(
+    tmp_path_factory: pytest.TempPathFactory, request: pytest.FixtureRequest
+) -> Generator[PostgresContainer | SimpleNamespace, None, None]:
+    """
+    Manages a PostgreSQL container for the test session.
+
+    If running with pytest-xdist, it uses file-based locking to ensure only
+    one container is created for all workers. Otherwise, it starts a
+    container for a normal single-process session.
+    """
+    if not is_xdist_worker(request):
+        # Standard, non-parallel execution
+        with PostgresContainer("postgres:16-alpine", driver="psycopg") as container:
+            yield container
+        return
+
+    # Parallel execution with pytest-xdist
+    worker_id = request.getfixturevalue("worker_id")
+    if worker_id == "master":
+        yield None
+        return
+
+    root_tmp_dir = tmp_path_factory.getbasetemp().parent
+    lock_file = root_tmp_dir / ".db.lock"
+    db_conn_file = root_tmp_dir / ".db.json"
+
+    with FileLock(str(lock_file)):
+        if not db_conn_file.is_file():
+            # Primary worker starts the container
+            container = PostgresContainer("postgres:16-alpine", driver="psycopg")
+            container.start()
+            conn_details = {"url": container.get_connection_url()}
+            db_conn_file.write_text(json.dumps(conn_details))
+            request.addfinalizer(container.stop)
+            request.addfinalizer(db_conn_file.unlink)
+            yield container
+        else:
+            # Secondary workers read connection info
+            conn_details = json.loads(db_conn_file.read_text())
+            yield SimpleNamespace(get_connection_url=lambda: conn_details["url"])
+
+
+@pytest.fixture(scope="session")
+def db_url(db_container: PostgresContainer | SimpleNamespace) -> str:
     """
     Fixture to get the database connection URL from the container.
     """
-    return db_container.get_connection_url()
+    if db_container:
+        return db_container.get_connection_url()
+    return None
 
 
 @pytest.fixture(scope="session", autouse=True)
-def setup_test_environment_and_db(db_url: str) -> None:
+def setup_test_environment_and_db(
+    db_url: str, request: pytest.FixtureRequest
+) -> None:
     """
-    Auto-used session-scoped fixture to set up the test environment.
+    Auto-used session-scoped fixture to set up the test environment and run migrations.
+    This is safe for both single-process and parallel execution.
     """
+    if not db_url:
+        return
+
     os.environ["BUILT_IN_OLLAMA_MODEL"] = "test-built-in-model"
     os.environ["DEFAULT_GENERATION_MODEL"] = "test-default-model"
     os.environ["DATABASE_URL"] = db_url
 
-    alembic_cfg = Config()
-    alembic_cfg.set_main_option("script_location", "alembic")
-    alembic_cfg.set_main_option("sqlalchemy.url", db_url)
-    command.upgrade(alembic_cfg, "head")
+    # In parallel mode, ensure migrations are run only once.
+    if is_xdist_worker(request):
+        root_tmp_dir = Path(os.environ["PYTEST_XDIST_TESTRUNUID"])
+        migration_lock_file = root_tmp_dir / ".migration.lock"
+        with FileLock(str(migration_lock_file)):
+            alembic_cfg = Config()
+            alembic_cfg.set_main_option("script_location", "alembic")
+            alembic_cfg.set_main_option("sqlalchemy.url", db_url)
+            command.upgrade(alembic_cfg, "head")
+    else:
+        # In single-process mode, just run the migration.
+        alembic_cfg = Config()
+        alembic_cfg.set_main_option("script_location", "alembic")
+        alembic_cfg.set_main_option("sqlalchemy.url", db_url)
+        command.upgrade(alembic_cfg, "head")
 
 
 @pytest.fixture
@@ -68,7 +130,6 @@ def db_session(db_url: str, monkeypatch) -> Generator[Session, None, None]:
         db.query(Log).delete()
         db.commit()
         db.close()
-        # Safely remove the override to avoid affecting other tests
         app.dependency_overrides.pop(create_db_session, None)
 
 
@@ -85,7 +146,6 @@ def mock_ollama_service() -> MagicMock:
 
     app.dependency_overrides[get_ollama_service] = lambda: mock_service
     yield mock_service
-    # Safely remove the override to avoid affecting other tests
     app.dependency_overrides.pop(get_ollama_service, None)
 
 


### PR DESCRIPTION
Implements a file-locking mechanism in the test fixtures to make them compatible with `pytest-xdist`.

Key changes:
- The `db_container` fixture in `tests/conftest.py` now uses `filelock` to ensure that only one test worker process manages the lifecycle of the PostgreSQL test container. The first worker to acquire the lock starts the container and writes the connection info to a shared file. Other workers wait and read from this file.
- The fixture is now compatible with both standard `pytest` runs and parallel `pytest-xdist` runs by checking for the presence of the `worker_id` fixture.
- Database migrations (Alembic) are also wrapped in a file lock to prevent concurrent execution.

build: Add `make clean` target for full environment reset

Adds a `clean` target to the `Makefile`. This new target stops and removes all Docker containers, networks, and crucially, volumes associated with the development environment. This provides a simple and reliable way for developers to completely reset their local setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能: なし（ユーザー向け変更はありません）
- Chores
  - 開発環境のクリーンアップ機能を強化し、ボリュームを含む一括削除が可能なコマンドを追加
- Tests
  - テストの並列実行に対応し、DBセットアップの競合を回避して安定性と速度を向上
- Dependencies
  - 開発用の依存パッケージを追加し、テスト実行時のロック管理を改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->