### PR TITLE
fix: Install main dependencies for test environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ help: ## Show this help message
 
 setup: ## Initialize project: install dependencies, create .env files and pull required Docker images.
 	@echo "Installing python dependencies with Poetry..."
-	@poetry install --no-root --only dev
+	@poetry install --no-root
 	@for env in dev prod test; do \
 		if [ ! -f .env.$${env} ]; then \
 			echo "Creating .env.$${env} from .env.example..."; \


### PR DESCRIPTION
The CI build was failing on the `test` step with a `ModuleNotFoundError` because main project dependencies like `sqlalchemy` were not being installed.

The `Makefile`'s `setup` target was using `poetry install --only dev`, which skips the installation of main dependencies. This change removes the `--only dev` flag to ensure that `poetry install` installs all required dependencies, allowing the test suite to run successfully.