### PR TITLE
feat(tests): Refactor DB test setup to use fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,15 +124,17 @@ lint-check: ## Check the code for issues with Ruff
 
 unit-test: ## Run the fast, database-independent unit tests locally
 	@echo "Running unit tests..."
-	@poetry run pytest tests/unit
+	@poetry run python -m pytest tests/unit
 
 db-test: ## Run the slower, database-dependent tests locally
 	@echo "Running database tests..."
-	@poetry run pytest --db tests/db
+	@VENV_PATH=$$(poetry env info -p); \
+	sudo $$VENV_PATH/bin/python -m pytest tests/db
 
 test: unit-test db-test e2e-test ## Run the full test suite (unit, db, and e2e)
 
 e2e-test: ## Run end-to-end tests against a live application stack
 	@echo "Running end-to-end tests..."
 	@ln -sf .env.test .env
-	@poetry run pytest tests/e2e
+	@VENV_PATH=$$(poetry env info -p); \
+	sudo $$VENV_PATH/bin/python -m pytest tests/e2e

--- a/Makefile
+++ b/Makefile
@@ -128,13 +128,11 @@ unit-test: ## Run the fast, database-independent unit tests locally
 
 db-test: ## Run the slower, database-dependent tests locally
 	@echo "Running database tests..."
-	@VENV_PATH=$$(poetry env info -p); \
-	sudo $$VENV_PATH/bin/python -m pytest tests/db
+	@poetry run python -m pytest tests/db
 
 test: unit-test db-test e2e-test ## Run the full test suite (unit, db, and e2e)
 
 e2e-test: ## Run end-to-end tests against a live application stack
 	@echo "Running end-to-end tests..."
 	@ln -sf .env.test .env
-	@VENV_PATH=$$(poetry env info -p); \
-	sudo $$VENV_PATH/bin/python -m pytest tests/e2e
+	@poetry run python -m pytest tests/e2e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
+pythonpath = "src"
 python_files = "test_*.py"
 asyncio_mode = "auto"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,0 @@
-def pytest_addoption(parser):
-    """Add a command line option to pytest to run database-dependent tests."""
-    parser.addoption(
-        "--db",
-        action="store_true",
-        default=False,
-        help="run database-dependent tests",
-    )

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -66,13 +66,17 @@ def db_setup(
             db_conn_file.write_text(db_url_value)
     else:  # worker node
         if not db_conn_file:
-            pytest.fail("xdist is running but the db_conn_file path could not be determined.")
+            pytest.fail(
+                "xdist is running but the db_conn_file path could not be determined."
+            )
 
         timeout = 20
         start_time = time.time()
         while not db_conn_file.exists():
             if time.time() - start_time > timeout:
-                pytest.fail(f"Worker could not find db_url.txt after {timeout} seconds.")
+                pytest.fail(
+                    f"Worker could not find db_url.txt after {timeout} seconds."
+                )
             time.sleep(0.1)
         db_url_value = db_conn_file.read_text()
 


### PR DESCRIPTION
Removes the global `--db` command-line option and the `pytest_configure` hook for setting up the test database.

The new implementation uses a session-scoped, autouse pytest fixture located in `tests/db/conftest.py`. This ensures that the database container is only started when tests inside the `tests/db` directory (or its subdirectories) are executed.

This change improves test suite efficiency by preventing unnecessary resource allocation when running non-database tests (e.g., unit tests) and simplifies the developer experience by removing the need for a special command-line flag.

The Makefile has been updated to reflect the simplified test commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- テスト
  - 単体・DB・E2Eテストの起動方式を見直し、仮想環境のPython経由で安定実行。
  - pytest設定にpythonpath=srcを追加し、テスト時のインポート解決を統一。
  - DBテスト基盤を刷新：セッションスコープの自動フィクスチャでPostgreSQLコンテナ起動/停止とマイグレーションを管理し、xdist環境で共有URL方式に対応。
  - 旧テストフラグ--dbを削除。

- 備考
  - 本変更は内部テスト基盤の改善であり、ユーザー向けの機能変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->