### PR TITLE
feat: Implement concurrency limiting for Ollama service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,14 @@ BUILT_IN_OLLAMA_MODEL=qwen3:0.6b
 HOST_BIND_IP=127.0.0.1
 HOST_PORT=50100
 
+# --- Ollama concurrency settings ---
+# OLLAMA_CONCURRENT_REQUEST_LIMIT: Max concurrent requests from the API to Ollama.
+OLLAMA_CONCURRENT_REQUEST_LIMIT=2
+# OLLAMA_NUM_PARALLEL: Max parallel requests Ollama will process internally.
+OLLAMA_NUM_PARALLEL=2
+# OLLAMA_MAX_LOADED_MODELS: Max number of models to keep loaded in VRAM.
+OLLAMA_MAX_LOADED_MODELS=1
+
 # --- Database settings ---
 DATABASE_URL=postgresql+psycopg://user:password@db:5432/pvt-llm-api
 POSTGRES_USER=user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     command: serve
     environment:
       - OLLAMA_HOST=0.0.0.0
+      - OLLAMA_NUM_PARALLEL=${OLLAMA_NUM_PARALLEL:-2}
+      - OLLAMA_MAX_LOADED_MODELS=${OLLAMA_MAX_LOADED_MODELS:-1}
     volumes:
       - ollama_data:/root/.ollama
     healthcheck:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A local LLM wrapped as an API for reusable access."
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"
-packages = [{ include = "*", from = "src" }]
+packages = [{ include = "src" }]
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
@@ -35,7 +35,6 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
-pythonpath = "src"
 python_files = "test_*.py"
 asyncio_mode = "auto"
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
 
     BUILT_IN_OLLAMA_MODEL: str
     DATABASE_URL: str
+    OLLAMA_CONCURRENT_REQUEST_LIMIT: int = 2
 
 
 @lru_cache

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -44,7 +44,9 @@ def db_setup(
 
     if is_master:
         load_dotenv()
-        os.environ["BUILT_IN_OLLAMA_MODEL"] = "test-built-in-model"
+        # Set a dummy model for DB tests, which don't need a real one.
+        # This is required for Alembic's env.py to validate settings.
+        os.environ["BUILT_IN_OLLAMA_MODEL"] = "test-db-model"
 
         container = PostgresContainer(
             "postgres:16-alpine",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import time
 from typing import Generator
@@ -13,7 +14,9 @@ def e2e_setup() -> Generator[None, None, None]:
     """
     Manages the lifecycle of the application for end-to-end testing.
     """
-    load_dotenv(".env.test")
+    # Load the E2E test environment, overriding any existing env vars
+    # to prevent contamination from other test fixtures (e.g., db_setup).
+    load_dotenv(".env.test", override=True)
     host_port = os.getenv("HOST_PORT", "8000")
     health_url = f"http://localhost:{host_port}/health"
 
@@ -46,59 +49,71 @@ def e2e_setup() -> Generator[None, None, None]:
         "--remove-orphans",
     ]
 
-    # Start services, ensuring cleanup on failure
-    print("\n🚀 Starting E2E services...")
-    print(f"Health check URL: {health_url}")
+    # Create a temporary .env file for docker-compose to use
+    shutil.copy(".env.test", ".env")
+
     try:
-        result = subprocess.run(
-            compose_up_command, check=True, timeout=300, capture_output=True, text=True
-        )  # 5 minutes timeout
-        print("Docker compose up output:", result.stdout)
-        if result.stderr:
-            print("Docker compose up stderr:", result.stderr)
-    except subprocess.CalledProcessError:
-        print("\n🛑 compose up failed; performing cleanup...")
-        subprocess.run(compose_down_command, check=False)
-        raise
-
-    # Health Check
-    start_time = time.time()
-    timeout = 300  # 5 minutes for qwen3:0.6b model download
-    is_healthy = False
-    while time.time() - start_time < timeout:
+        # Start services, ensuring cleanup on failure
+        print("\n🚀 Starting E2E services...")
+        print(f"Health check URL: {health_url}")
         try:
-            response = httpx.get(health_url, timeout=5)
-            if response.status_code == 200:
-                print("✅ API is healthy!")
-                is_healthy = True
-                break
-        except httpx.RequestError as e:
-            print(f"⏳ API not yet healthy, retrying... Error: {e}")
-            time.sleep(5)
+            result = subprocess.run(
+                compose_up_command,
+                check=True,
+                timeout=300,
+                capture_output=True,
+                text=True,
+            )  # 5 minutes timeout
+            print("Docker compose up output:", result.stdout)
+            if result.stderr:
+                print("Docker compose up stderr:", result.stderr)
+        except subprocess.CalledProcessError:
+            print("\n🛑 compose up failed; performing cleanup...")
+            subprocess.run(compose_down_command, check=False)
+            raise
 
-    if not is_healthy:
-        subprocess.run(
-            docker_command
-            + [
-                "compose",
-                "--env-file",
-                ".env.test",
-                "-f",
-                "docker-compose.yml",
-                "-f",
-                "docker-compose.override.yml",
-                "logs",
-                "api",
-                "ollama",
-            ]
-        )
-        # Ensure teardown on health check failure
-        print("\n🛑 Stopping E2E services due to health check failure...")
-        subprocess.run(compose_down_command, check=False)
-        pytest.fail(f"API did not become healthy within {timeout} seconds.")
+        # Health Check
+        start_time = time.time()
+        timeout = 300  # 5 minutes for qwen3:0.6b model download
+        is_healthy = False
+        while time.time() - start_time < timeout:
+            try:
+                response = httpx.get(health_url, timeout=5)
+                if response.status_code == 200:
+                    print("✅ API is healthy!")
+                    is_healthy = True
+                    break
+            except httpx.RequestError as e:
+                print(f"⏳ API not yet healthy, retrying... Error: {e}")
+                time.sleep(5)
 
-    yield
+        if not is_healthy:
+            subprocess.run(
+                docker_command
+                + [
+                    "compose",
+                    "--env-file",
+                    ".env.test",
+                    "-f",
+                    "docker-compose.yml",
+                    "-f",
+                    "docker-compose.override.yml",
+                    "logs",
+                    "api",
+                    "ollama",
+                ]
+            )
+            # Ensure teardown on health check failure
+            print("\n🛑 Stopping E2E services due to health check failure...")
+            subprocess.run(compose_down_command, check=False)
+            pytest.fail(f"API did not become healthy within {timeout} seconds.")
 
-    # Stop services
-    print("\n🛑 Stopping E2E services...")
-    subprocess.run(compose_down_command, check=True)
+        yield
+
+        # Stop services
+        print("\n🛑 Stopping E2E services...")
+        subprocess.run(compose_down_command, check=True)
+    finally:
+        # Clean up the temporary .env file
+        if os.path.exists(".env"):
+            os.remove(".env")


### PR DESCRIPTION
This commit introduces a concurrency limiting mechanism to prevent the API from overwhelming the backend Ollama service. It also includes several critical fixes to the project's configuration and test environment that were necessary to validate the changes.

Key changes:
- **Concurrency Control:**
  - `OllamaService` is refactored to use an `asyncio.Semaphore` to limit the number of concurrent requests sent to the Ollama backend.
  - The limit is configured via a new `OLLAMA_CONCURRENT_REQUEST_LIMIT` setting.
  - The service's constructor now accepts a `Settings` object via dependency injection.
  - Comments in `.env.example` and `ollama_service.py` were improved for clarity.

- **Configuration:**
  - Added `OLLAMA_CONCURRENT_REQUEST_LIMIT`, `OLLAMA_NUM_PARALLEL`, and `OLLAMA_MAX_LOADED_MODELS` to `.env.example`.
  - The `ollama` service in `docker-compose.yml` is updated to receive `OLLAMA_NUM_PARALLEL` and `OLLAMA_MAX_LOADED_MODELS`.

- **Test Environment Fixes:**
  - Corrected the package configuration in `pyproject.toml` to resolve module pathing issues.
  - Created a `.env.test` file, which was required by the E2E tests.
  - Modified the E2E test fixture to handle `.env` file conflicts with `docker-compose`.
  - Resolved an environment variable conflict between the DB and E2E test fixtures that was causing incorrect test setup.

**Testing Status:**
After these fixes, 17 out of 18 tests pass. The final E2E test fails due to a persistent `no space left on device` error from the Docker daemon in the execution environment. This environmental issue is outside the scope of code changes to resolve. The implemented logic and test fixes are believed to be correct.